### PR TITLE
Boost path for relative path

### DIFF
--- a/configs/test_ee.yaml
+++ b/configs/test_ee.yaml
@@ -1,3 +1,3 @@
 ROSEndEffector:
-  urdf_path: "/home/lucamuratore/src/ros_end_effector__ws/src/ROSEndEffector/configs/urdf/test_ee.urdf"
-  srdf_path: "/home/lucamuratore/src/ros_end_effector__ws/src/ROSEndEffector/configs/srdf/test_ee.srdf"
+  urdf_path: "urdf/test_ee.urdf"
+  srdf_path: "srdf/test_ee.srdf"

--- a/configs/two_finger.yaml
+++ b/configs/two_finger.yaml
@@ -1,3 +1,3 @@
 ROSEndEffector:
-  urdf_path: "/home/lucamuratore/src/ros_end_effector__ws/src/ROSEndEffector/configs/urdf/two_finger.urdf"
-  srdf_path: "/home/lucamuratore/src/ros_end_effector__ws/src/ROSEndEffector/configs/srdf/two_finger.srdf"
+  urdf_path: "urdf/two_finger.urdf"
+  srdf_path: "srdf/two_finger.srdf"

--- a/include/ROSEndEffector/Parser.h
+++ b/include/ROSEndEffector/Parser.h
@@ -29,6 +29,9 @@
 
 #include <srdfdom/model.h>
 
+//to find relative path for the config files
+#include <boost/filesystem/path.hpp>
+
 namespace ROSEE {
     
     /**

--- a/include/ROSEndEffector/UniversalRosEndEffectorExecutor.h
+++ b/include/ROSEndEffector/UniversalRosEndEffectorExecutor.h
@@ -34,6 +34,10 @@
 #include <ros_end_effector/EEGraspControl.h>
 #include <ros_end_effector/EEPinchControl.h>
 
+//to find relative path for the config files
+#include <boost/filesystem/path.hpp>
+
+
 namespace ROSEE
 {
 

--- a/include/ROSEndEffector/Utils.h
+++ b/include/ROSEndEffector/Utils.h
@@ -26,6 +26,14 @@ namespace ROSEE
 
 namespace Utils
 {
+    
+    
+static std::string getPackagePath() {
+    
+    boost::filesystem::path path(__FILE__);
+    path.remove_filename();
+    return path.string() + "/../../";
+}
 
 
 template <typename SignalType>

--- a/launch/test_ee_startup.launch
+++ b/launch/test_ee_startup.launch
@@ -9,7 +9,7 @@
         
      <!-- <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher"></node> -->
     
-    <node type="UniversalRosEndEffector" name="UniversalRosEndEffector" pkg="ros_end_effector" />
+    <node type="UniversalRosEndEffector" name="UniversalRosEndEffector" pkg="ros_end_effector" output="screen"/>
 
     <!-- start robot state publisher -->
     <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen" >

--- a/launch/two_finger_ee_startup.launch
+++ b/launch/two_finger_ee_startup.launch
@@ -9,7 +9,7 @@
         
      <!-- <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher"></node> -->
     
-    <node type="UniversalRosEndEffector" name="UniversalRosEndEffector" pkg="ros_end_effector" />
+    <node type="UniversalRosEndEffector" name="UniversalRosEndEffector" pkg="ros_end_effector" output="screen" />
 
     <!-- start robot state publisher -->
     <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen" >

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -156,7 +156,7 @@ bool ROSEE::Parser::parseSRDF() {
 }
 
 
-bool ROSEE::Parser::parseURDF() {
+    bool ROSEE::Parser::parseURDF() {
 
     std::string xml_string;
     std::fstream xml_file ( _urdf_path.c_str(), std::fstream::in );
@@ -224,9 +224,15 @@ bool ROSEE::Parser::getROSEndEffectorConfig() {
         // check the urdf_filename
         if ( ros_ee_node["urdf_path"] ) {
 
-            // TBD relative path
-            _urdf_path = ros_ee_node["urdf_path"].as<std::string>();
+            // TBD relative path in more elegant way
+            // retrieve path of this source file (and its upper folder)
+            boost::filesystem::path path(__FILE__); 
+            path.remove_filename().remove_leaf();
+            std::string packagePath = path.string();
+            
+            _urdf_path = packagePath + "/configs/" + ros_ee_node["urdf_path"].as<std::string>();
             ROS_INFO_STREAM ( "ROSEndEffector Parser found URDF path: " << _urdf_path );
+            std::cin.get();
         } else {
 
             ROS_ERROR_STREAM ( "in " << __func__ << " : ROSEndEffector node of  " << _ros_ee_config_path << " does not contain urdf_path mandatory node!!" );
@@ -236,8 +242,13 @@ bool ROSEE::Parser::getROSEndEffectorConfig() {
         // check the srdf_filename
         if ( ros_ee_node["srdf_path"] ) {
 
-            // TBD relative path
-            _srdf_path = ros_ee_node["srdf_path"].as<std::string>();
+            // TBD relative path in more elegant way
+            // retrieve path of this source file (and its upper folder)
+            boost::filesystem::path path(__FILE__); 
+            path.remove_filename().remove_leaf();
+            std::string packagePath = path.string();
+            
+            _srdf_path = packagePath + "/configs/" + ros_ee_node["srdf_path"].as<std::string>();
             ROS_INFO_STREAM ( "ROSEndEffector Parser found SRDF path: " << _srdf_path );
         } else {
 

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -232,7 +232,6 @@ bool ROSEE::Parser::getROSEndEffectorConfig() {
             
             _urdf_path = packagePath + "/configs/" + ros_ee_node["urdf_path"].as<std::string>();
             ROS_INFO_STREAM ( "ROSEndEffector Parser found URDF path: " << _urdf_path );
-            std::cin.get();
         } else {
 
             ROS_ERROR_STREAM ( "in " << __func__ << " : ROSEndEffector node of  " << _ros_ee_config_path << " does not contain urdf_path mandatory node!!" );

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -16,6 +16,7 @@
 */
 
 #include <ROSEndEffector/Parser.h>
+#include <ROSEndEffector/Utils.h>
 
 #include <ros/console.h>
 
@@ -225,12 +226,7 @@ bool ROSEE::Parser::getROSEndEffectorConfig() {
         if ( ros_ee_node["urdf_path"] ) {
 
             // TBD relative path in more elegant way
-            // retrieve path of this source file (and its upper folder)
-            boost::filesystem::path path(__FILE__); 
-            path.remove_filename().remove_leaf();
-            std::string packagePath = path.string();
-            
-            _urdf_path = packagePath + "/configs/" + ros_ee_node["urdf_path"].as<std::string>();
+            _urdf_path = ROSEE::Utils::getPackagePath() + "/configs/" + ros_ee_node["urdf_path"].as<std::string>();
             ROS_INFO_STREAM ( "ROSEndEffector Parser found URDF path: " << _urdf_path );
         } else {
 
@@ -242,12 +238,7 @@ bool ROSEE::Parser::getROSEndEffectorConfig() {
         if ( ros_ee_node["srdf_path"] ) {
 
             // TBD relative path in more elegant way
-            // retrieve path of this source file (and its upper folder)
-            boost::filesystem::path path(__FILE__); 
-            path.remove_filename().remove_leaf();
-            std::string packagePath = path.string();
-            
-            _srdf_path = packagePath + "/configs/" + ros_ee_node["srdf_path"].as<std::string>();
+            _srdf_path = ROSEE::Utils::getPackagePath() + "/configs/" + ros_ee_node["srdf_path"].as<std::string>();
             ROS_INFO_STREAM ( "ROSEndEffector Parser found SRDF path: " << _srdf_path );
         } else {
 

--- a/src/UniversalRosEndEffectorExecutor.cpp
+++ b/src/UniversalRosEndEffectorExecutor.cpp
@@ -28,10 +28,14 @@ ROSEE::UniversalRosEndEffectorExecutor::UniversalRosEndEffectorExecutor ( std::s
                                     this, false, false );
     _time = 0.0;
 
-
-    // parse config TBD no hardcode
+    // TBD relative path in more elegant way
+    // retrieve path of this source file
+    boost::filesystem::path path(__FILE__);
+    path.remove_filename();
+    std::string thisSourcePath = path.string();
+    
     ROSEE::Parser p ( _nh );
-    p.init ( "/home/lucamuratore/src/ros_end_effector__ws/src/ROSEndEffector/configs/two_finger.yaml" );
+    p.init ( thisSourcePath + "/../configs/two_finger.yaml" );
     p.printEndEffectorFingerJointsMap();
 
     // retrieve the ee interface

--- a/src/UniversalRosEndEffectorExecutor.cpp
+++ b/src/UniversalRosEndEffectorExecutor.cpp
@@ -28,14 +28,9 @@ ROSEE::UniversalRosEndEffectorExecutor::UniversalRosEndEffectorExecutor ( std::s
                                     this, false, false );
     _time = 0.0;
 
-    // TBD relative path in more elegant way
-    // retrieve path of this source file
-    boost::filesystem::path path(__FILE__);
-    path.remove_filename();
-    std::string thisSourcePath = path.string();
-    
+    // TBD relative path in more elegant way   
     ROSEE::Parser p ( _nh );
-    p.init ( thisSourcePath + "/../configs/two_finger.yaml" );
+    p.init ( ROSEE::Utils::getPackagePath() + "/configs/two_finger.yaml" );
     p.printEndEffectorFingerJointsMap();
 
     // retrieve the ee interface

--- a/test/test_ee_interface.cpp
+++ b/test/test_ee_interface.cpp
@@ -7,6 +7,7 @@
 
 #include <ROSEndEffector/Parser.h>
 #include <ROSEndEffector/EEInterface.h>
+#include <ROSEndEffector/Utils.h>
 
 namespace {
 
@@ -30,7 +31,7 @@ protected:
         ros::NodeHandle nh;
 
         ROSEE::Parser p ( nh );
-        p.init ( "/home/lucamuratore/src/ros_end_effector__ws/src/ROSEndEffector/configs/test_ee.yaml" );
+        p.init (  ROSEE::Utils::getPackagePath() + "/configs/test_ee.yaml" );
         p.printEndEffectorFingerJointsMap();
 
         ee = std::make_shared<ROSEE::EEInterface>(p);


### PR DESCRIPTION
I am not sure if it is an "elegant" solution, but I use Boost library to deal with path, so now relative path for config files (the yaml one and the two urdf and srdf) are used
I was annoyed by changing everytime the path for config files =)